### PR TITLE
Add ReadOnly Wallet

### DIFF
--- a/src/lib/wallet/adapters/index.ts
+++ b/src/lib/wallet/adapters/index.ts
@@ -7,6 +7,7 @@ import { MetaMask } from "./metamask";
 import { XDefi } from "./xdefi";
 import { WalletAdapter, type Connectable } from "./types";
 import { signer } from "../stores";
+import { ReadOnly } from "./readonly";
 
 export async function adapterToIWallet(adapter: WalletAdapter): Promise<Connectable | null> {
     switch (adapter) {
@@ -28,12 +29,15 @@ export async function adapterToIWallet(adapter: WalletAdapter): Promise<Connecta
         case WalletAdapter.XDefi:
             const { XDefi } = await import("./xdefi");
             return XDefi;
+        case WalletAdapter.Readonly:
+            const { ReadOnly } = await import("./readonly");
+            return ReadOnly;
         default:
             return null;
     }
 }
 
-export const WALLETS: Connectable[] = [Sonar, /*MetaMask,*/ Keplr, Leap, Station, XDefi];
+export const WALLETS: Connectable[] = [Sonar, /*MetaMask,*/ Keplr, Leap, Station, XDefi, ReadOnly];
 
 let hasSetupEventListeners = false;
 export function setupEventListeners(): void {

--- a/src/lib/wallet/adapters/readonly.ts
+++ b/src/lib/wallet/adapters/readonly.ts
@@ -1,0 +1,48 @@
+import { writable } from "svelte/store";
+import type { GasPrice } from "@cosmjs/stargate";
+import type { TendermintClient } from "@cosmjs/tendermint-rpc";
+import type { AccountData as CosmAccountData, EncodeObject } from "@cosmjs/proto-signing";
+import { WalletAdapter, type AccountData, type WalletMetadata, ConnectionError, type ISigner } from "./types";
+
+export let ViewOnlyAddress = writable<string | null>(null);
+
+export class ReadOnly implements ISigner {
+    private constructor(private acc: AccountData) { }
+
+    public static async connect(chain: string): Promise<ReadOnly> {
+
+        //TODO: Missing wallet input from user
+        const account: AccountData = {
+            address: 'kujira1w29z0mzn7sx48xrcke0nzsr8gcwvcel7euj9mk',
+            pubkey: {
+                type: '',
+                value: ''
+            }
+        }
+
+        return new ReadOnly(account);
+    }
+    public disconnect() { /* noop */ }
+
+    public static metadata: WalletMetadata = {
+        adapter: WalletAdapter.Readonly,
+        name: 'View Only',
+        logo: '',
+        canSign: false,
+    }
+    public getMetadata(): WalletMetadata { return ReadOnly.metadata; }
+
+    public static async isInstalled(): Promise<boolean> { return true; }
+
+    public account(): AccountData { return this.acc; }
+
+    public async sign(
+        client: TendermintClient,
+        msgs: EncodeObject[],
+        gasLimit: number,
+        gasPrice: GasPrice,
+        memo?: string
+    ): Promise<Uint8Array> {
+        return new Uint8Array();
+    }
+}

--- a/src/lib/wallet/adapters/types.ts
+++ b/src/lib/wallet/adapters/types.ts
@@ -5,6 +5,7 @@ import type { MetaMask } from "./metamask";
 import type { Sonar } from "./sonar";
 import type { Station } from "./station";
 import type { XDefi } from "./xdefi";
+import type { ReadOnly } from "./readonly";
 import type { GasPrice } from "@cosmjs/stargate";
 import type { TendermintClient } from "@cosmjs/tendermint-rpc";
 import type { Pubkey } from "@cosmjs/amino";
@@ -43,7 +44,7 @@ type ISignerStatic<T> = {
     isInstalled(): Promise<boolean>;
     metadata: WalletMetadata;
 };
-export type Connectable = ISignerStatic<Keplr> | ISignerStatic<Sonar> | ISignerStatic<Leap> | ISignerStatic<MetaMask> | ISignerStatic<Station> | ISignerStatic<XDefi>;
+export type Connectable = ISignerStatic<Keplr> | ISignerStatic<Sonar> | ISignerStatic<Leap> | ISignerStatic<MetaMask> | ISignerStatic<Station> | ISignerStatic<XDefi> | ISignerStatic<ReadOnly>;
 
 export interface ISigner {
     disconnect: () => void;


### PR DESCRIPTION
Initial support for View or Read only wallets.

Wallet input is missing.

![2023-12-06_08-48](https://github.com/EntropicLabs/kujira-svelte/assets/2390220/c91fc7aa-294e-49e9-946d-76e98de1610e)
